### PR TITLE
Fixed compile error

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -74,10 +74,10 @@ export default class Command {
                     } else {
                         switch (typeof obj.payload) {
                             case "string":
-                                payload = Buffer.from(obj.payload);
+                                payload = Buffer.from(obj.payload.toString());
                                 break;
                             case "object":
-                                payload = Buffer.from(JSON.stringify(obj.payload));
+                                payload = Buffer.from(JSON.stringify(obj.payload.toString()));
                                 break;
                         }
                     }


### PR DESCRIPTION
Solves following error:
```
src/command.ts(77,55): error TS2345: Argument of type 'string | object' is not assignable to parameter of type 'string'.
  Type 'object' is not assignable to type 'string'.
```